### PR TITLE
fix: use real ethereum address when calling third party

### DIFF
--- a/src/logic/third-party-url-parser.ts
+++ b/src/logic/third-party-url-parser.ts
@@ -2,6 +2,7 @@ import { parseUrn } from '@dcl/urn-resolver'
 import { ThirdPartyProvider } from '../types'
 
 const URN_THIRD_PARTY_NAME_TYPE = 'blockchain-collection-third-party-name'
+const ANY_WALLET = '0x6438c3b1fa97ba144ea38fcbcee5f0ccf4539b1d'
 
 export default async function parse(thirdPartyProvider: ThirdPartyProvider): Promise<string> {
   const parsedUrn = await parseUrn(thirdPartyProvider.id)
@@ -11,7 +12,7 @@ export default async function parse(thirdPartyProvider: ThirdPartyProvider): Pro
   }
 
   const baseUrl = new URL(thirdPartyProvider.resolver).href.replace(/\/$/, '')
-  const url = `${baseUrl}/registry/${parsedUrn.thirdPartyName}/address/any/assets`
+  const url = `${baseUrl}/registry/${parsedUrn.thirdPartyName}/address/${ANY_WALLET}/assets`
 
   return url
 }

--- a/test/unit/url-parser.spec.ts
+++ b/test/unit/url-parser.spec.ts
@@ -11,7 +11,9 @@ describe('url-parser should', () => {
 
     const result = await sut(thirdPartyProvider)
 
-    expect(result).toBe('https://third-party-resolver-api.decentraland.zone/v1/registry/ignore-me/address/any/assets')
+    expect(result).toBe(
+      'https://third-party-resolver-api.decentraland.zone/v1/registry/ignore-me/address/0x6438c3b1fa97ba144ea38fcbcee5f0ccf4539b1d/assets'
+    )
   })
 
   it('throw an error if the Third Party Provider id is invalid', async () => {


### PR DESCRIPTION
This PR updates the method of fetching third-party providers to determine their health status. Going forward, these requests will utilize an actual Ethereum address for evaluation purposes.