### PR TITLE
fix: Send empty array when the third-party-providers fetch fails

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -32,7 +32,8 @@ export async function initComponents(injectedComponents?: Partial<AppComponents>
   const thirdPartyProviderHealthChecker = createThirdPartyProviderHealthComponent({ fetch, logs, metrics })
   const thirdPartyProvidersMemoryStorage = createThirdPartyProvidersMemoryStorage({
     thirdPartyProvidersFetcher,
-    thirdPartyProviderHealthChecker
+    thirdPartyProviderHealthChecker,
+    logs
   })
 
   await instrumentHttpServerWithPromClientRegistry({ metrics, server, config, registry: metrics.registry! })


### PR DESCRIPTION
This PR logs when the third-party-providers fetch fails instead of throwing an error to avoid crashing the server.